### PR TITLE
Return a default response if there is no reason provided.

### DIFF
--- a/requests_mock/response.py
+++ b/requests_mock/response.py
@@ -14,6 +14,7 @@ import json as jsonutils
 
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.response import HTTPResponse
+from requests import status_codes
 import six
 
 from requests_mock import compat
@@ -147,10 +148,15 @@ class _MatcherResponse(object):
         # if an error was requested then raise that instead of doing response
         if self._exc:
             raise self._exc
-
+        status_code = self._params.get('status_code', _DEFAULT_STATUS)
+        # if there is no reason provided use default reason for
+        # current status code.
+        reason = self._params.get(
+            'reason',
+            status_codes._codes.get(status_code, [''])[0].capitalize())
         context = _Context(self._params.get('headers', {}).copy(),
-                           self._params.get('status_code', _DEFAULT_STATUS),
-                           self._params.get('reason'))
+                           status_code,
+                           reason)
 
         # if a body element is a callback then execute it
         def _call(f, *args, **kwargs):


### PR DESCRIPTION
When we got a 401 request back, requests library raises an error with following arguments
```
('401 Client Error: Unauthorized',)
```

But when we mock the the library with requests-mock, we get the error with following arguments
```
('401 Client Error: None',)
```

This pr tries to fix the issue by using default reason from requests library if no reason is provided.
